### PR TITLE
BOM in bower.json breaks newer versions of bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "angular-routing",
   "version": "0.4.3",
   "main": "./build/angular-routing.min.js",


### PR DESCRIPTION
I'm having some trouble with bower being unable to parse bower.json due to a BOM  at the start of the file.

It looks like this was ok in bower 0.9.2 (I happen to have that version in the environment for one of my projects), but not in 1.2.6.
