### PR TITLE
bower: update bower.json acc to the spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "dotjem-angular-routing",
-  "version": "0.6.10",
-  "main": [ "build/angular-routing.min.js", "build/angular-routing.js" ],
+  "main": [ "build/angular-routing.js" ],
   "dependencies": {
     "angular": ">= 1.2"
   }


### PR DESCRIPTION
Bower uses git tags and ignores the `version` field, so you may safely remove this line.
See https://github.com/bower/bower.json-spec#version
Also according to the same spec, minified files shouldn't be included to `main`.
