### PR TITLE
Fix the 'regex' converter so that parameters can be reused

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -477,6 +477,9 @@ var $RouteProvider = [<any>'$locationProvider',
                     };
                 },
                 format: (value) => {
+                    if (angular.isArray(value)) {
+                        value = value[0];
+                    }
                     var str = value.toString();
                     var test = regex.test(str);
                     if (!test) {


### PR DESCRIPTION
The docs for `$state` say: "If the state has an associated route, that route will be activated and the location with change it the address bar of the browser. It is also important that all parameters are defined for such route, **however if the previous state defines any of those, they won't need to be redefined**." As for now, the last part (bold) of the last sentence isn't true when the `regex` converter is used.
