### PR TITLE
Avoid race in jem-view when scope is destroyed before template is loaded

### DIFF
--- a/src/directives/jemView.ts
+++ b/src/directives/jemView.ts
@@ -144,6 +144,10 @@ var jemViewDirective = [<any>'$state', '$compile', '$controller', '$view', '$ani
                             controller = view.controller;
 
                             view.template.then((html) => {
+                                if (scope.$$destroyed) {
+                                    return;
+                                }
+
                                 var newScope = scope.$new();
                                 linker(newScope, function (clone) {
                                     cleanupView(doAnimate);


### PR DESCRIPTION
We ran into this in our application when we redefined a mid level view for a state to use a custom controller, but the same template.  I *think* there is a transition in effect that could be playing a part in the timing.

The following is pseudo-code that attempts to describe the situation.  I'll work on getting a working demonstration and/or test case.

```javascript
$state
.state('top', {
  route: '',
  views: {
    middle: { template: 'middle.html' },
    header: template: 'header.html' },
  },
})
.state('top.foo', {
  route: 'foo',
  views: {
    // The foo module is pretty simple and fits into one view
    main: { template: 'foo.html', controller: 'FooCtrl' },
  },
})
.state('top.bar', {
  route: 'bar',
  views: {
    // The bar module is special and injects it's controller into the middle view so it can share data with it's special bar header.
    middle: { template: 'middle.html', controller: 'BarCtrl as bar' },
    header: { template: 'bar-header.html' },
    main: { template: 'bar.html' },
  },
})
```

```html
<!-- middle.html -->
<header jem-view=header>
<div jem-view=main>
```

```html
<!-- header.html -->
<nav>
  <a href=/foo>foo</a>
  <a href=/bar>bar</a>
  breadcrumbs or something
</nav>
```

```html
<!-- foo.html -->
Welcome to foo
```

```html
<!-- bar-header.html -->
There are {{bar.count}} bar
<button ng-click="bar.create()">+ New<button>
```

```html
<!-- bar.html -->
Welcome to bar
```

1. When transitioning from `top.foo` to `top.bar` there is an old `jem-view=middle` and a new `jem-view=middle`, each contain a `jem-view=main`.
2. The old `jem-view=main` observes a view event and it's `update()` requests the template.  At this point the `jem-view` is still a descendant of the root element and its scope is still valid.
3. The old `jem-view=middle` scope is destroyed and detached from it's parent.
4. The old `jem-view=main` proceeds to compile and link the template contents against a new child scope.

Directives in the template will not see a `$destroy` event (it already fired), and can therefore leak resources.
